### PR TITLE
compatibility with non-boost shared_pointers

### DIFF
--- a/src/SMURFParser.cpp
+++ b/src/SMURFParser.cpp
@@ -32,7 +32,7 @@ namespace smurf_parser {
 
   
   /**Replaces relative paths inside the urdf model with absolut paths. */
-  void relativeToAbsolut(boost::shared_ptr<urdf::ModelInterface> model,
+  void relativeToAbsolut(urdf::ModelInterfaceSharedPtr model,
                          const std::string& urdfPathStr)
   {
     assert(urdfPathStr.size() > 0);
@@ -42,17 +42,17 @@ namespace smurf_parser {
     boost::filesystem::path urdfPath(urdfPathStr);
     urdfPath.remove_filename(); 
      
-    std::map<std::string, boost::shared_ptr<urdf::Link> >::iterator it;
+    std::map<std::string, urdf::LinkSharedPtr >::iterator it;
     for(it = model->links_.begin(); it != model->links_.end(); ++it)
     {
-      std::vector<boost::shared_ptr<urdf::Visual> >& visuals = it->second->visual_array;
-      std::vector<boost::shared_ptr<urdf::Visual> >::iterator visIt;
+      std::vector<urdf::VisualSharedPtr>& visuals = it->second->visual_array;
+      std::vector<urdf::VisualSharedPtr>::iterator visIt;
       for(visIt = visuals.begin(); visIt != visuals.end(); ++visIt)
       {
-        boost::shared_ptr<urdf::Geometry> geometry = (*visIt)->geometry;
+        urdf::GeometrySharedPtr geometry = (*visIt)->geometry;
         if(geometry->type == urdf::Geometry::MESH)
         {
-          boost::shared_ptr<urdf::Mesh> mesh = boost::dynamic_pointer_cast<urdf::Mesh>(geometry);
+          urdf::MeshSharedPtr mesh = urdf::dynamic_pointer_cast<urdf::Mesh>(geometry);
           assert(mesh != NULL); //otherwise implementation error in parser
           boost::filesystem::path path(mesh->filename);
           if(!path.is_absolute())
@@ -68,7 +68,7 @@ namespace smurf_parser {
   }
   
   
-  boost::shared_ptr<urdf::ModelInterface> parseFile(configmaps::ConfigMap* map,
+  urdf::ModelInterfaceSharedPtr parseFile(configmaps::ConfigMap* map,
           std::string path, std::string smurffilename, bool expandURIs) {
 
     path+="/"; // secure that path and file are combined correctly
@@ -92,10 +92,10 @@ namespace smurf_parser {
 
     // parse URDF model and return
     fprintf(stderr, "  ...loading urdf data from %s.\n", urdfpath.c_str());
-    boost::shared_ptr<urdf::ModelInterface> model = urdf::parseURDFFile(urdfpath);
+    urdf::ModelInterfaceSharedPtr model = urdf::parseURDFFile(urdfpath);
     
     if (!model) {
-      return boost::shared_ptr<urdf::ModelInterface>();
+      return urdf::ModelInterfaceSharedPtr();
     }
     
     //there might be relative paths inside the model. Since we do not return the urdf path 

--- a/src/SMURFParser.h
+++ b/src/SMURFParser.h
@@ -30,12 +30,12 @@
 #endif
 
 #include <boost/function.hpp>
-#include <urdf_model/model.h>
+#include <urdf_world/types.h>
 #include <configmaps/ConfigData.h>
 
 namespace smurf_parser {
 
-    boost::shared_ptr<urdf::ModelInterface> parseFile(configmaps::ConfigMap* map,
+    urdf::ModelInterfaceSharedPtr parseFile(configmaps::ConfigMap* map,
       std::string path, std::string smurffilename, bool expandURIs);
 
 } // end of namespace smurf_parser


### PR DESCRIPTION
urdf seems to have switched from `boost::shared_ptr` to `std::shared_ptr`, but it provides typedefs for compatibity.
